### PR TITLE
Fix syntax error in models.Model.

### DIFF
--- a/transDjango/APIimports/models.py
+++ b/transDjango/APIimports/models.py
@@ -4,16 +4,15 @@ from django.db import models
 from .modelDefinitions.CIPpoint import *
 
 
-from django.db import models
 from django.contrib.postgres import fields as pg_fields
 
-class ApiElement(Models.model):
+class ApiElement(models.Model):
     # The actual object represented by the api
     payload = pg_fields.JSONField()
     queryTime = models.DateTimeField()
     url = models.CharField(max_length=2083)
 
-class Project(Models.model):
+class Project(models.Model):
     geom = models.MultiPointField()
     bureau = models.CharField(max_length=1000)
     contact = models.CharField(max_length=1000)


### PR DESCRIPTION
Encountered a "no module named Models" error when attempting to run the example file on my machine. Replacing with "models.Model" ran fine. Can you please verify that this is what was intended.