### PR TITLE
implement monkey patching to eliminate worker timeouts

### DIFF
--- a/transDjango/docker-entrypoint.sh
+++ b/transDjango/docker-entrypoint.sh
@@ -10,4 +10,4 @@ python manage.py collectstatic --noinput
 
 # Fire up a lightweight frontend to host the Django endpoints - gunicorn was the default choice
 # gevent used to address ELB/gunicorn issue here https://github.com/benoitc/gunicorn/issues/1194
-gunicorn transDjango.wsgi:application -b :8000 --worker-class 'gevent'
+gunicorn transDjango.wsgi:application -b :8000 --worker-class 'gevent' --workers 1

--- a/transDjango/requirements.txt
+++ b/transDjango/requirements.txt
@@ -16,7 +16,7 @@ geopy==1.11.0
 networkx==1.11
 awscli
 whitenoise
-
+psycogreen
 
 # find out which ones of these are needed
 #appdirs==1.4.0

--- a/transDjango/transDjango/wsgi.py
+++ b/transDjango/transDjango/wsgi.py
@@ -12,6 +12,14 @@ import os
 from whitenoise.django import DjangoWhiteNoise
 from django.core.wsgi import get_wsgi_application
 
+# Monkey patching the application to help stabilize the Docker container deploy
+# Deploying Docker containers to ECS often timed out and the new container would get killed by ALB
+# That problem disappeared completely once this monkey patching was implemented
+from psycogreen.gevent import patch_psycopg
+from gevent import monkey; monkey.patch_all()
+
+patch_psycopg()
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "transDjango.settings")
 
 application = get_wsgi_application()


### PR DESCRIPTION
This is the configuration that we've implemented on the rest of the backend projects to eliminate the irritating and sometimes-deploy-interrupting CRITICAL WORKER TIMEOUT problem with gunicorn.

I've tested this on a local Docker container build and it worked flawlessly.

This is exactly the same configuration as we've implemented on the other backend apps.