### PR TITLE
Move CorsMiddleware to load first - following the pattern we've used on other Backend projects

### DIFF
--- a/transDjango/transDjango/settings.py
+++ b/transDjango/transDjango/settings.py
@@ -59,9 +59,10 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    # CorsMiddleware should be placed as high as possible and before CommonMiddleware response generator
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
Following the pattern we used elsewhere - put CorsMiddleware as high in the load order as possible, which is the documented advice for CorsMiddleware.