### PR TITLE
Addressing command line error from issue #49

### DIFF
--- a/transDjango/setup-linux.sh
+++ b/transDjango/setup-linux.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+
+# USAGE:
+# $ chmod +x setup-linux.sh
+# $ ./setup-linux.sh
+#
+# OR:
+# $ bash setup-linux.sh
+
+# if this script is executing then we are already inside of a working copy tree cloned from the repo
+#git clone https://github.com/hackoregon/transportation-backend.git
+#cd transportation-backend
+
+# install apt packages missing from a clean Linux Mint 18.2 install
+sudo apt-get install -y virtualenv libpq-dev python3-dev postgresql-contrib
+
+# create and activate a virtualenv
+virtualenv -p python3 venv
+source venv/bin/activate
+
+# install python module requirements into virtualenv
+pip install -r requirements.txt
+
+# MacOS Homebrew packages?
+#brew install gdal
+#brew install libgeoip
+
+# install equivalent apt packages for Debian/Ubuntu/Mint systems
+sudo apt-get install -y gdal-bin libgeoip1
+
+# this command fails on my system
+#psql postgres

--- a/transDjango/setup-linux.sh
+++ b/transDjango/setup-linux.sh
@@ -7,6 +7,9 @@
 # OR:
 # $ bash setup-linux.sh
 
+# below steps copied originally from transportation-backend/transDjango/README.md 
+# see: https://github.com/hackoregon/transportation-backend/blob/master/transDjango/README.md
+
 # if this script is executing then we are already inside of a working copy tree cloned from the repo
 #git clone https://github.com/hackoregon/transportation-backend.git
 #cd transportation-backend


### PR DESCRIPTION
Addressing issue #49:

1. add bash .sh script setup-linux.sh that executes the relevant commands originally described in /transDjango/README.md (https://github.com/hackoregon/transportation-backend/blob/master/transDjango/README.md)

2. fix the command line erro regarding psycopg2 python module compilation resulting from executing the command line steps described in the README.md

*(command line steps call for installing python module 'psycopg2' but that command attempts to build the module thus requiring the appropriate c++ libraries are present on the linux system or the compilation step will fail. These include python3-dev and libpq-dev and must be installed via apt prior to running the pip install step.)*


