### PR TITLE
update requests pip package to address security alert

### DIFF
--- a/transDjango/requirements.txt
+++ b/transDjango/requirements.txt
@@ -6,7 +6,7 @@ djangorestframework-gis==0.11
 django-rest-swagger==2.1.1
 psycopg2==2.6.2
 python-dateutil==2.6.0
-requests==2.13.0
+requests==2.20.0
 six==1.10.0
 gunicorn
 gevent==1.2.1


### PR DESCRIPTION
>1 requests vulnerability found in transDjango/requirements.txt on Oct 29, 2018
Remediation
Upgrade requests to version 2.20.0 or later. For example:

>requests>=2.20.0

https://nvd.nist.gov/vuln/detail/CVE-2018-18074

Updated requests pip package specified in requirements.txt from 2.13.0 to 2.20.0